### PR TITLE
fix: ecmaFeatures.experimentalObjectRestSperead 제거

### DIFF
--- a/eslint-config-airbnb-base/index.js
+++ b/eslint-config-airbnb-base/index.js
@@ -6,16 +6,13 @@ module.exports = {
     "./rules/style",
     "./rules/variables",
     "./rules/es6",
-    "./rules/imports",
+    "./rules/imports"
   ].map(require.resolve),
   parserOptions: {
     ecmaVersion: 2017,
-    sourceType: "module",
-    ecmaFeatures: {
-      experimentalObjectRestSpread: true,
-    },
+    sourceType: "module"
   },
   rules: {
-    strict: "error",
-  },
+    strict: "error"
+  }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-naver",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-naver",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Naver JavaScript Coding Conventions rules for eslint",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
- :ambulance: `eslint-config-airbnb-base/index.js` 에 아직 까지 남아 있던 `ecmaFeatures.experimentalObjectRestSperead` parsetOptions 제거
  - 최신 eslint tool 들과 연동하여 사용시 warning 뜨며 진행되지 않을 가능성이 있었음




