### PR TITLE
:ambulance: ecmaVersion 을 2018로 변경

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2017 NAVER Corp.
+Copyright (c) 2019 NAVER Corp.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@
 `eslint-config-naver` is released under the [MIT license](LICENSE).
 
 ```
-Copyright (c) 2017 NAVER Corp.
+Copyright (c) 2019 NAVER Corp.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/eslint-config-airbnb-base/index.js
+++ b/eslint-config-airbnb-base/index.js
@@ -9,7 +9,7 @@ module.exports = {
     "./rules/imports"
   ].map(require.resolve),
   parserOptions: {
-    ecmaVersion: 2017,
+    ecmaVersion: 2018,
     sourceType: "module"
   },
   rules: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-naver",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-naver",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "description": "Naver JavaScript Coding Conventions rules for eslint",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
- ecmaFeatures.experimentalObjectSpread 제거시, ecmaVersion 을 2018로 바꿔야 해당 문법을 사용할 수 있음
- patch 버전으로 수정시, `eslint@4.x` 사용자에게도 `ecmaVersion: 2018`이 강제 적용될 수 있음
  - `v2.0.3` 을 deprecates 하고, `v2.1.0`으로 minor change 로 변경

