### PR TITLE
Remove JSCS link

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -82,7 +82,7 @@
     const b = 2;
     ```
 
-  - [2.2](#2.2) <a name='2.2'></a> 참조를 재할당 해야한다면 `var` 대신 `let` 을 사용한다.  eslint: [`no-var`](http://eslint.org/docs/rules/no-var.html) jscs: [`disallowVar`](http://jscs.info/rule/disallowVar)
+  - [2.2](#2.2) <a name='2.2'></a> 참조를 재할당 해야한다면 `var` 대신 `let` 을 사용한다.  eslint: [`no-var`](http://eslint.org/docs/rules/no-var.html)
 
     ```javascript
     // bad


### PR DESCRIPTION
The link to JSCS home page is broken. Since [JSCS has been "merged" into ESLint in 2016](https://medium.com/@markelog/jscs-end-of-the-line-bc9bf0b3fdb2) and is seldom used, we can remove mentions of JSCS to keep the documentation lean.

Note: Alternatively, we could fix the link to https://jscs-dev.github.io/rule/disallowVar. But there is no guarantee that this link will be available in the future.